### PR TITLE
fix: lang terms need to be in double-quoted strings

### DIFF
--- a/lang/ar.js
+++ b/lang/ar.js
@@ -1,7 +1,9 @@
+/* eslint quotes: 0 */
+
 export default {
-	'aria.steplabel': 'الخطوة {currentStep} من أصل {totalSteps}',
-	'stepper.defaults.next': 'التالي',
-	'stepper.defaults.restart': 'إعادة تشغيل',
-	'restart.button.tooltip': 'Back to first step',
-	'next.button.tooltip': 'Proceed to next step'
+	"aria.steplabel": "الخطوة {currentStep} من أصل {totalSteps}",
+	"stepper.defaults.next": "التالي",
+	"stepper.defaults.restart": "إعادة تشغيل",
+	"restart.button.tooltip": "Back to first step",
+	"next.button.tooltip": "Proceed to next step"
 };

--- a/lang/cy-gb.js
+++ b/lang/cy-gb.js
@@ -1,7 +1,9 @@
+/* eslint quotes: 0 */
+
 export default {
-	'aria.steplabel': 'Step {currentStep} of {totalSteps}',
-	'stepper.defaults.next': 'Next',
-	'stepper.defaults.restart': 'Ailddechrau',
-	'restart.button.tooltip': 'Back to first step',
-	'next.button.tooltip': 'Proceed to next step'
+	"aria.steplabel": "Step {currentStep} of {totalSteps}",
+	"stepper.defaults.next": "Next",
+	"stepper.defaults.restart": "Ailddechrau",
+	"restart.button.tooltip": "Back to first step",
+	"next.button.tooltip": "Proceed to next step"
 };

--- a/lang/da-dk.js
+++ b/lang/da-dk.js
@@ -1,7 +1,9 @@
+/* eslint quotes: 0 */
+
 export default {
-	'aria.steplabel': 'Trin {currentStep} af {totalSteps}',
-	'stepper.defaults.next': 'Næste',
-	'stepper.defaults.restart': 'Genstart',
-	'restart.button.tooltip': 'Back to first step',
-	'next.button.tooltip': 'Proceed to next step'
+	"aria.steplabel": "Trin {currentStep} af {totalSteps}",
+	"stepper.defaults.next": "Næste",
+	"stepper.defaults.restart": "Genstart",
+	"restart.button.tooltip": "Back to first step",
+	"next.button.tooltip": "Proceed to next step"
 };

--- a/lang/de.js
+++ b/lang/de.js
@@ -1,7 +1,9 @@
+/* eslint quotes: 0 */
+
 export default {
-	'aria.steplabel': 'Schritt {currentStep} von {totalSteps}',
-	'stepper.defaults.next': 'Weiter',
-	'stepper.defaults.restart': 'Neu starten',
-	'restart.button.tooltip': 'Back to first step',
-	'next.button.tooltip': 'Proceed to next step'
+	"aria.steplabel": "Schritt {currentStep} von {totalSteps}",
+	"stepper.defaults.next": "Weiter",
+	"stepper.defaults.restart": "Neu starten",
+	"restart.button.tooltip": "Back to first step",
+	"next.button.tooltip": "Proceed to next step"
 };

--- a/lang/en.js
+++ b/lang/en.js
@@ -1,7 +1,9 @@
+/* eslint quotes: 0 */
+
 export default {
-	'aria.steplabel': 'Step {currentStep} of {totalSteps}',
-	'stepper.defaults.next': 'Next',
-	'stepper.defaults.restart': 'Restart',
-	'restart.button.tooltip': 'Back to first step',
-	'next.button.tooltip': 'Proceed to next step'
+	"aria.steplabel": "Step {currentStep} of {totalSteps}",
+	"stepper.defaults.next": "Next",
+	"stepper.defaults.restart": "Restart",
+	"restart.button.tooltip": "Back to first step",
+	"next.button.tooltip": "Proceed to next step"
 };

--- a/lang/es-es.js
+++ b/lang/es-es.js
@@ -1,7 +1,9 @@
+/* eslint quotes: 0 */
+
 export default {
-	'aria.steplabel': 'Step {currentStep} of {totalSteps}',
-	'stepper.defaults.next': 'Next',
-	'stepper.defaults.restart': 'Reiniciar',
-	'restart.button.tooltip': 'Back to first step',
-	'next.button.tooltip': 'Proceed to next step'
+	"aria.steplabel": "Step {currentStep} of {totalSteps}",
+	"stepper.defaults.next": "Next",
+	"stepper.defaults.restart": "Reiniciar",
+	"restart.button.tooltip": "Back to first step",
+	"next.button.tooltip": "Proceed to next step"
 };

--- a/lang/es.js
+++ b/lang/es.js
@@ -1,7 +1,9 @@
+/* eslint quotes: 0 */
+
 export default {
-	'aria.steplabel': 'Paso {currentStep} de {totalSteps}',
-	'stepper.defaults.next': 'Siguiente',
-	'stepper.defaults.restart': 'Reiniciar',
-	'restart.button.tooltip': 'Back to first step',
-	'next.button.tooltip': 'Proceed to next step'
+	"aria.steplabel": "Paso {currentStep} de {totalSteps}",
+	"stepper.defaults.next": "Siguiente",
+	"stepper.defaults.restart": "Reiniciar",
+	"restart.button.tooltip": "Back to first step",
+	"next.button.tooltip": "Proceed to next step"
 };

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -1,7 +1,9 @@
+/* eslint quotes: 0 */
+
 export default {
-	'aria.steplabel': 'Étape {currentStep} sur {totalSteps}',
-	'stepper.defaults.next': 'Suivant',
-	'stepper.defaults.restart': 'Redémarrer',
-	'restart.button.tooltip': 'Back to first step',
-	'next.button.tooltip': 'Proceed to next step'
+	"aria.steplabel": "Étape {currentStep} sur {totalSteps}",
+	"stepper.defaults.next": "Suivant",
+	"stepper.defaults.restart": "Redémarrer",
+	"restart.button.tooltip": "Back to first step",
+	"next.button.tooltip": "Proceed to next step"
 };

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -1,7 +1,9 @@
+/* eslint quotes: 0 */
+
 export default {
-	'aria.steplabel': 'Étape {currentStep} de {totalSteps}',
-	'stepper.defaults.next': 'Suivant',
-	'stepper.defaults.restart': 'Redémarrer',
-	'restart.button.tooltip': 'Back to first step',
-	'next.button.tooltip': 'Proceed to next step'
+	"aria.steplabel": "Étape {currentStep} de {totalSteps}",
+	"stepper.defaults.next": "Suivant",
+	"stepper.defaults.restart": "Redémarrer",
+	"restart.button.tooltip": "Back to first step",
+	"next.button.tooltip": "Proceed to next step"
 };

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -1,7 +1,9 @@
+/* eslint quotes: 0 */
+
 export default {
-	'aria.steplabel': 'ステップ {currentStep}/{totalSteps}',
-	'stepper.defaults.next': '次へ',
-	'stepper.defaults.restart': '再開',
-	'restart.button.tooltip': 'Back to first step',
-	'next.button.tooltip': 'Proceed to next step'
+	"aria.steplabel": "ステップ {currentStep}/{totalSteps}",
+	"stepper.defaults.next": "次へ",
+	"stepper.defaults.restart": "再開",
+	"restart.button.tooltip": "Back to first step",
+	"next.button.tooltip": "Proceed to next step"
 };

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -1,7 +1,9 @@
+/* eslint quotes: 0 */
+
 export default {
-	'aria.steplabel': '{currentStep}/{totalSteps} 단계',
-	'stepper.defaults.next': '다음',
-	'stepper.defaults.restart': '다시 시작',
-	'restart.button.tooltip': 'Back to first step',
-	'next.button.tooltip': 'Proceed to next step'
+	"aria.steplabel": "{currentStep}/{totalSteps} 단계",
+	"stepper.defaults.next": "다음",
+	"stepper.defaults.restart": "다시 시작",
+	"restart.button.tooltip": "Back to first step",
+	"next.button.tooltip": "Proceed to next step"
 };

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -1,7 +1,9 @@
+/* eslint quotes: 0 */
+
 export default {
-	'aria.steplabel': 'Stap {currentStep} van {totalSteps}',
-	'stepper.defaults.next': 'Volgende',
-	'stepper.defaults.restart': 'Opnieuw starten',
-	'restart.button.tooltip': 'Back to first step',
-	'next.button.tooltip': 'Proceed to next step'
+	"aria.steplabel": "Stap {currentStep} van {totalSteps}",
+	"stepper.defaults.next": "Volgende",
+	"stepper.defaults.restart": "Opnieuw starten",
+	"restart.button.tooltip": "Back to first step",
+	"next.button.tooltip": "Proceed to next step"
 };

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -1,7 +1,9 @@
+/* eslint quotes: 0 */
+
 export default {
-	'aria.steplabel': 'Etapa {currentStep} de {totalSteps}',
-	'stepper.defaults.next': 'Next',
-	'stepper.defaults.restart': 'Reiniciar',
-	'restart.button.tooltip': 'Back to first step',
-	'next.button.tooltip': 'Proceed to next step'
+	"aria.steplabel": "Etapa {currentStep} de {totalSteps}",
+	"stepper.defaults.next": "Next",
+	"stepper.defaults.restart": "Reiniciar",
+	"restart.button.tooltip": "Back to first step",
+	"next.button.tooltip": "Proceed to next step"
 };

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -1,7 +1,9 @@
+/* eslint quotes: 0 */
+
 export default {
-	'aria.steplabel': 'Steg {currentStep} av {totalSteps}',
-	'stepper.defaults.next': 'Nästa',
-	'stepper.defaults.restart': 'Starta om',
-	'restart.button.tooltip': 'Back to first step',
-	'next.button.tooltip': 'Proceed to next step'
+	"aria.steplabel": "Steg {currentStep} av {totalSteps}",
+	"stepper.defaults.next": "Nästa",
+	"stepper.defaults.restart": "Starta om",
+	"restart.button.tooltip": "Back to first step",
+	"next.button.tooltip": "Proceed to next step"
 };

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -1,7 +1,9 @@
+/* eslint quotes: 0 */
+
 export default {
-	'aria.steplabel': 'Adım {currentStep} / {totalSteps}',
-	'stepper.defaults.next': 'Next',
-	'stepper.defaults.restart': 'Yeniden Başlat',
-	'restart.button.tooltip': 'Back to first step',
-	'next.button.tooltip': 'Proceed to next step'
+	"aria.steplabel": "Adım {currentStep} / {totalSteps}",
+	"stepper.defaults.next": "Next",
+	"stepper.defaults.restart": "Yeniden Başlat",
+	"restart.button.tooltip": "Back to first step",
+	"next.button.tooltip": "Proceed to next step"
 };

--- a/lang/zh-TW.js
+++ b/lang/zh-TW.js
@@ -1,7 +1,9 @@
+/* eslint quotes: 0 */
+
 export default {
-	'aria.steplabel': '第 {currentStep} 步，共 {totalSteps} 步',
-	'stepper.defaults.next': 'Next',
-	'stepper.defaults.restart': '重新開始',
-	'restart.button.tooltip': 'Back to first step',
-	'next.button.tooltip': 'Proceed to next step'
+	"aria.steplabel": "第 {currentStep} 步，共 {totalSteps} 步",
+	"stepper.defaults.next": "Next",
+	"stepper.defaults.restart": "重新開始",
+	"restart.button.tooltip": "Back to first step",
+	"next.button.tooltip": "Proceed to next step"
 };

--- a/lang/zh.js
+++ b/lang/zh.js
@@ -1,7 +1,9 @@
+/* eslint quotes: 0 */
+
 export default {
-	'aria.steplabel': '全部 {currentStep} 步中的 {totalSteps} 步',
-	'stepper.defaults.next': 'Next',
-	'stepper.defaults.restart': '重新开始',
-	'restart.button.tooltip': 'Back to first step',
-	'next.button.tooltip': 'Proceed to next step'
+	"aria.steplabel": "全部 {currentStep} 步中的 {totalSteps} 步",
+	"stepper.defaults.next": "Next",
+	"stepper.defaults.restart": "重新开始",
+	"restart.button.tooltip": "Back to first step",
+	"next.button.tooltip": "Proceed to next step"
 };


### PR DESCRIPTION
For the Serge.io integration to work properly, lang terms need to be in double-quoted strings. Otherwise it won't escape single quotes within the terms properly.