### PR TITLE
ci: Remove visual-diff for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "lint:lit": "lit-analyzer custom-ads-scheduler.js demo test",
     "start": "es-dev-server --app-index demo/index.html --node-resolve --dedupe --open --watch",
     "test": "npm run lint && npm run test:headless",
-    "test:diff": "mocha ./**/*.visual-diff.js -t 40000",
-    "test:diff:golden": "mocha ./**/*.visual-diff.js -t 40000 --golden",
-    "test:diff:golden:commit": "commit-goldens",
     "test:headless": "karma start",
     "test:headless:watch": "karma start --auto-watch=true --single-run=false",
     "test:sauce": "karma start karma.sauce.conf.js"
@@ -55,7 +52,6 @@
     "wct-browser-legacy": "^1",
     "lit-analyzer": "^1",
     "karma-sauce-launcher": "^4",
-    "@brightspace-ui/visual-diff": "^2",
     "@open-wc/testing": "^2",
     "@open-wc/testing-karma": "^4"
   }


### PR DESCRIPTION
This repo doesn't have any visual-diff tests yet.  I'm going to remove the `package.json` references (which I'm removing from all the visual-diff repos anyways), and then the workflow and README updates can be added whenever the visual diff tests are added.