### PR TITLE
Boolean attribute to expand label width to 150px

### DIFF
--- a/d2l-single-step-header.js
+++ b/d2l-single-step-header.js
@@ -73,12 +73,7 @@ class D2LSingleStepHeader extends LocalizeMixin(LitElement) {
 			}
 
 			:host([fill-header-width]) .d2l-labs-single-step-header-step-title {
-				background: none !important;
-				border: none !important;
-				color: var(--d2l-color-ferrite);
-				margin: auto;
 				max-width: 150px;
-				overflow-wrap: break-word;
 			}
 
 			.d2l-labs-single-step-header-done-icon {
@@ -133,6 +128,7 @@ class D2LSingleStepHeader extends LocalizeMixin(LitElement) {
 		this.totalSteps = 0;
 		this.currentStep = 0;
 		this.selectedStep = 0;
+		this.fillHeaderWidth = false;
 	}
 
 	render() {

--- a/d2l-single-step-header.js
+++ b/d2l-single-step-header.js
@@ -2,6 +2,7 @@ import { css, html, LitElement } from 'lit-element';
 import { bodySmallStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { getLocalizeResources } from './localization.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { styleMap } from 'lit-html/directives/style-map.js';
 
 class D2LSingleStepHeader extends LocalizeMixin(LitElement) {
 
@@ -22,6 +23,10 @@ class D2LSingleStepHeader extends LocalizeMixin(LitElement) {
 			selectedStep: {
 				type: Number,
 				attribute: 'selected-step'
+			},
+			fillHeaderWidth: {
+				type: Boolean,
+				attribute: 'fill-header-width'
 			}
 		};
 	}
@@ -63,7 +68,6 @@ class D2LSingleStepHeader extends LocalizeMixin(LitElement) {
 				border: none !important;
 				color: var(--d2l-color-ferrite);
 				margin: auto;
-				max-width: 120px;
 				overflow-wrap: break-word;
 			}
 
@@ -119,9 +123,13 @@ class D2LSingleStepHeader extends LocalizeMixin(LitElement) {
 		this.totalSteps = 0;
 		this.currentStep = 0;
 		this.selectedStep = 0;
+		this.fillHeaderWidth = false;
 	}
 
 	render() {
+		const width = {
+			'max-width': this.fillHeaderWidth ? '150px' : '120px',
+		};
 		return html`
 			<div class="${this._getIsFirst()} ${this._getIsLast()}">
 				<div class="d2l-labs-single-step-header-step">
@@ -135,8 +143,7 @@ class D2LSingleStepHeader extends LocalizeMixin(LitElement) {
 
 						<hr>
 					</div>
-
-					<div class="${this._getProgressStatus()} d2l-labs-single-step-header-step-title d2l-body-small">${this.title}</div>
+					<div class="${this._getProgressStatus()} d2l-labs-single-step-header-step-title d2l-body-small" style="${styleMap(width)}"></div>${this.title}</div>
 				</div>
 			</div>
 		`;

--- a/d2l-single-step-header.js
+++ b/d2l-single-step-header.js
@@ -145,7 +145,7 @@ class D2LSingleStepHeader extends LocalizeMixin(LitElement) {
 
 						<hr>
 					</div>
-					<div class="${this._getProgressStatus()} d2l-labs-single-step-header-step-title d2l-body-small"></div>${this.title}</div>
+					<div class="${this._getProgressStatus()} d2l-labs-single-step-header-step-title d2l-body-small">${this.title}</div>
 				</div>
 			</div>
 		`;

--- a/d2l-single-step-header.js
+++ b/d2l-single-step-header.js
@@ -2,7 +2,6 @@ import { css, html, LitElement } from 'lit-element';
 import { bodySmallStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { getLocalizeResources } from './localization.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
-import { styleMap } from 'lit-html/directives/style-map.js';
 
 class D2LSingleStepHeader extends LocalizeMixin(LitElement) {
 
@@ -26,7 +25,8 @@ class D2LSingleStepHeader extends LocalizeMixin(LitElement) {
 			},
 			fillHeaderWidth: {
 				type: Boolean,
-				attribute: 'fill-header-width'
+				attribute: 'fill-header-width',
+				reflect: true
 			}
 		};
 	}
@@ -68,6 +68,16 @@ class D2LSingleStepHeader extends LocalizeMixin(LitElement) {
 				border: none !important;
 				color: var(--d2l-color-ferrite);
 				margin: auto;
+				max-width: 120px;
+				overflow-wrap: break-word;
+			}
+
+			:host([fill-header-width]) .d2l-labs-single-step-header-step-title {
+				background: none !important;
+				border: none !important;
+				color: var(--d2l-color-ferrite);
+				margin: auto;
+				max-width: 150px;
 				overflow-wrap: break-word;
 			}
 
@@ -123,13 +133,9 @@ class D2LSingleStepHeader extends LocalizeMixin(LitElement) {
 		this.totalSteps = 0;
 		this.currentStep = 0;
 		this.selectedStep = 0;
-		this.fillHeaderWidth = false;
 	}
 
 	render() {
-		const width = {
-			'max-width': this.fillHeaderWidth ? '150px' : '120px',
-		};
 		return html`
 			<div class="${this._getIsFirst()} ${this._getIsLast()}">
 				<div class="d2l-labs-single-step-header-step">
@@ -143,7 +149,7 @@ class D2LSingleStepHeader extends LocalizeMixin(LitElement) {
 
 						<hr>
 					</div>
-					<div class="${this._getProgressStatus()} d2l-labs-single-step-header-step-title d2l-body-small" style="${styleMap(width)}"></div>${this.title}</div>
+					<div class="${this._getProgressStatus()} d2l-labs-single-step-header-step-title d2l-body-small"></div>${this.title}</div>
 				</div>
 			</div>
 		`;

--- a/d2l-wizard.js
+++ b/d2l-wizard.js
@@ -18,7 +18,8 @@ class D2LWizard extends LitElement {
 			},
 			fillHeaderWidth: {
 				type: Boolean,
-				attribute: 'fill-header-width'
+				attribute: 'fill-header-width',
+				reflect: true
 			}
 		};
 	}
@@ -42,7 +43,6 @@ class D2LWizard extends LitElement {
 		this.stepTitles = [];
 		this.stepCount = 0;
 		this.selectedStep = 0;
-		this.fillHeaderWidth = false;
 	}
 
 	render() {

--- a/d2l-wizard.js
+++ b/d2l-wizard.js
@@ -15,6 +15,10 @@ class D2LWizard extends LitElement {
 			selectedStep: {
 				type: Number,
 				attribute: 'selected-step'
+			},
+			fillHeaderWidth: {
+				type: Boolean,
+				attribute: 'fill-header-width'
 			}
 		};
 	}
@@ -38,6 +42,7 @@ class D2LWizard extends LitElement {
 		this.stepTitles = [];
 		this.stepCount = 0;
 		this.selectedStep = 0;
+		this.fillHeaderWidth = false;
 	}
 
 	render() {
@@ -45,7 +50,7 @@ class D2LWizard extends LitElement {
 			<div class="d2l-labs-wizard-header">
 				${this.stepTitles.map((title, index) =>
 		html`
-						<d2l-labs-single-step-header total-steps="${this.stepCount}" current-step="${index}" selected-step="${this.selectedStep}" title="${title}"></d2l-labs-single-step-header>
+						<d2l-labs-single-step-header total-steps="${this.stepCount}" current-step="${index}" selected-step="${this.selectedStep}" title="${title}" ?fill-header-width="${this.fillHeaderWidth}"></d2l-labs-single-step-header>
 					`)}
 
 			</div>

--- a/d2l-wizard.js
+++ b/d2l-wizard.js
@@ -43,6 +43,7 @@ class D2LWizard extends LitElement {
 		this.stepTitles = [];
 		this.stepCount = 0;
 		this.selectedStep = 0;
+		this.fillHeaderWidth = false;
 	}
 
 	render() {

--- a/demo/index.html
+++ b/demo/index.html
@@ -7,37 +7,38 @@
 	<script src="@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '@brightspace-ui/core/components/demo/demo-page.js';
-		import '../d2l-wizard.js';
 		import '../d2l-step.js';
+		import '../d2l-wizard.js';
 	</script>
+	<style>
+		.wizard {
+          display: flex;
+          flex: 1;
+          width: 100%;
+          justify-content: center;
+          margin: 30px 0px;
+          overflow-x: auto;
+        }
+	</style>
 </head>
 
 <body unresolved>
 	<d2l-demo-page page-title="d2l-labs-wizard">
 		<h2>Basic Wizard</h2>
 		<d2l-demo-snippet>
-			<d2l-labs-wizard id="wizard" selected-step="1">
-				<d2l-labs-step next-button-aria-label="Go to step 2" title="Lets get started" hide-restart-button="true">
+			<d2l-labs-wizard id="wizard" selected-step="1" ?fill-header-width="true">
+				<d2l-labs-step next-button-aria-label="Go to step 2" title="Request approved" hide-restart-button="true">
 					<p> first step </p>
 				</d2l-labs-step>
 
-				<d2l-labs-step aria-title="This is the second step" restart-button-tooltip="Restart this wizard">
+				<d2l-labs-step aria-title="This is the second step" title="Employee Registered" restart-button-tooltip="Restart this wizard">
 					<p> second step </p>
 				</d2l-labs-step>
 
-				<d2l-labs-step title="Almost done" next-button-title="Done" next-button-tooltip="Save this wizard" >
+				<d2l-labs-step title="Program completed" next-button-title="Done" next-button-tooltip="Save this wizard" >
 					<p> Last step </p>
 				</d2l-labs-step>
 			</d2l-labs-wizard>
-			<script>
-				const wizard = document.getElementById('wizard');
-				wizard.addEventListener('stepper-next', () => {
-					wizard.next();
-				});
-				wizard.addEventListener('stepper-restart', () => {
-					wizard.restart();
-				});
-			</script>
 		</d2l-demo-snippet>
 
 	</d2l-demo-page>

--- a/demo/index.html
+++ b/demo/index.html
@@ -7,38 +7,37 @@
 	<script src="@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '@brightspace-ui/core/components/demo/demo-page.js';
-		import '../d2l-step.js';
 		import '../d2l-wizard.js';
+		import '../d2l-step.js';
 	</script>
-	<style>
-		.wizard {
-          display: flex;
-          flex: 1;
-          width: 100%;
-          justify-content: center;
-          margin: 30px 0px;
-          overflow-x: auto;
-        }
-	</style>
 </head>
 
 <body unresolved>
 	<d2l-demo-page page-title="d2l-labs-wizard">
 		<h2>Basic Wizard</h2>
 		<d2l-demo-snippet>
-			<d2l-labs-wizard id="wizard" selected-step="1" ?fill-header-width="true">
-				<d2l-labs-step next-button-aria-label="Go to step 2" title="Request approved" hide-restart-button="true">
+			<d2l-labs-wizard id="wizard" selected-step="1">
+				<d2l-labs-step next-button-aria-label="Go to step 2" title="Lets get started" hide-restart-button="true">
 					<p> first step </p>
 				</d2l-labs-step>
 
-				<d2l-labs-step aria-title="This is the second step" title="Employee Registered" restart-button-tooltip="Restart this wizard">
+				<d2l-labs-step aria-title="This is the second step" restart-button-tooltip="Restart this wizard">
 					<p> second step </p>
 				</d2l-labs-step>
 
-				<d2l-labs-step title="Program completed" next-button-title="Done" next-button-tooltip="Save this wizard" >
+				<d2l-labs-step title="Almost done" next-button-title="Done" next-button-tooltip="Save this wizard" >
 					<p> Last step </p>
 				</d2l-labs-step>
 			</d2l-labs-wizard>
+			<script>
+				const wizard = document.getElementById('wizard');
+				wizard.addEventListener('stepper-next', () => {
+					wizard.next();
+				});
+				wizard.addEventListener('stepper-restart', () => {
+					wizard.restart();
+				});
+			</script>
 		</d2l-demo-snippet>
 
 	</d2l-demo-page>


### PR DESCRIPTION
By default the `max-width` of the `d2l-labs-single-step-header-step-title` class is 120px but by doing:
 `<d2l-labs-wizard id="wizard" selected-step="1" fill-header-width>`
 or 
 `<d2l-labs-single-step-header aria-hidden="true" total-steps="4" current-step="0" selected-step="1" fill-header-width>`
 you can expand it to 150px.