### PR TITLE
Adding currentStep() and Hide option to Next button

### DIFF
--- a/d2l-step.js
+++ b/d2l-step.js
@@ -27,6 +27,10 @@ class D2LStep extends LocalizeMixin(LitElement) {
 				type: Boolean,
 				attribute: 'hide-restart-button'
 			},
+			hideNextButton: {
+				type: Boolean,
+				attribute: 'hide-next-button'
+			},
 			disableNextButton: {
 				type: Boolean,
 				attribute: 'disable-next-button'
@@ -39,7 +43,7 @@ class D2LStep extends LocalizeMixin(LitElement) {
 				type: String,
 				attribute: 'restart-button-aria-label'
 			},
-			ariaTitle:{
+			ariaTitle: {
 				type: String,
 				attribute: 'aria-title'
 			},
@@ -79,6 +83,7 @@ class D2LStep extends LocalizeMixin(LitElement) {
 	constructor() {
 		super();
 		this.hideRestartButton = false;
+		this.hideNextButton = false;
 		this.disableNextButton = false;
 		this.nextButtonAriaLabel = '';
 		this.restartButtonAriaLabel = '';
@@ -93,9 +98,31 @@ class D2LStep extends LocalizeMixin(LitElement) {
 			<div id="aria-title" tabindex="0" class="d2l-offscreen">${this._getAriaTitle()}</div>
 			<slot></slot>
 			<div class="d2l-labs-step-footer">
-				${this.hideRestartButton ? html`<div></div>` : html`<d2l-button title="${ !this.restartButtonTooltip ? this.localize('restart.button.tooltip') : this.restartButtonTooltip }" aria-label="${this.restartButtonAriaLabel}" @click="${this._restartClick}">${!this.restartButtonTitle ? this.localize('stepper.defaults.restart') : this.restartButtonTitle}</d2l-button>`}
+	${this.hideRestartButton
+		? html`<div></div>`
+		: html`
+			<d2l-button
+				title="${!this.restartButtonTooltip ? this.localize('restart.button.tooltip') : this.restartButtonTooltip}"
+				aria-label="${this.restartButtonAriaLabel}"
+				@click="${this._restartClick}"
+			>
+			${!this.restartButtonTitle ? this.localize('stepper.defaults.restart') : this.restartButtonTitle}
+			</d2l-button>`}
 
-				<d2l-button class="d2l-labs-step-button-next" title="${ !this.nextButtonTooltip ? this.localize('next.button.tooltip') : this.nextButtonTooltip }" aria-label="${this.nextButtonAriaLabel}" @click="${this._nextClick}" primary ?disabled="${this.disableNextButton}">${!this.nextButtonTitle ? this.localize('stepper.defaults.next') : this.nextButtonTitle}</d2l-button>
+	${this.hideNextButton
+		? html`<div></div>`
+		: html`
+			<d2l-button
+				class="d2l-labs-step-button-next"
+				title="${!this.nextButtonTooltip ? this.localize('next.button.tooltip') : this.nextButtonTooltip}"
+				aria-label="${this.nextButtonAriaLabel}"
+				@click="${this._nextClick}"
+				primary
+				?disabled="${this.disableNextButton}"
+			>
+			${!this.nextButtonTitle ? this.localize('stepper.defaults.next') : this.nextButtonTitle}
+			</d2l-button>`}
+
 			</div>
 		`;
 	}

--- a/d2l-wizard.js
+++ b/d2l-wizard.js
@@ -59,6 +59,10 @@ class D2LWizard extends LitElement {
 		`;
 	}
 
+	currentStep() {
+		return this.selectedStep;
+	}
+
 	next() {
 		this.selectedStep = (this.selectedStep + 1) === this.stepCount ? this.selectedStep : (this.selectedStep + 1);
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,7 +4,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-	<script src="@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script type="module">
 		import '@brightspace-ui/core/components/demo/demo-page.js';
 		import '../d2l-wizard.js';
@@ -25,7 +25,7 @@
 					<p> second step </p>
 				</d2l-labs-step>
 
-				<d2l-labs-step title="Almost done" next-button-title="Done" next-button-tooltip="Save this wizard" >
+				<d2l-labs-step title="Almost done" next-button-title="Done" next-button-tooltip="Save this wizard">
 					<p> Last step </p>
 				</d2l-labs-step>
 			</d2l-labs-wizard>
@@ -39,7 +39,16 @@
 				});
 			</script>
 		</d2l-demo-snippet>
-
+		<d2l-demo-snippet>
+			<d2l-labs-wizard id="wizard2" selected-step="0">
+				<d2l-labs-step title="Lets get started" hide-restart-button="true" hide-next-button="true">
+					<p> first step </p>
+				</d2l-labs-step>
+				<d2l-labs-step title="Last done" hide-restart-button="true" hide-next-button="true">
+					<p> Last step </p>
+				</d2l-labs-step>
+			</d2l-labs-wizard>
+		</d2l-demo-snippet>
 	</d2l-demo-page>
 </body>
 


### PR DESCRIPTION
- Introducing a `currentStep()` funtion in wizard component which returns the currently selected step of the wizard.
- Adding an option to hide Next button from the wizard-step component.
![image](https://user-images.githubusercontent.com/62559837/120381383-5a6d8a80-c2f0-11eb-8629-4fa836ab84be.png)
