### PR TITLE
US135825 Lit 2 Migration - Phase 1

### DIFF
--- a/d2l-single-step-header.js
+++ b/d2l-single-step-header.js
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from 'lit-element';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { bodySmallStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { getLocalizeResources } from './localization.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';

--- a/d2l-step.js
+++ b/d2l-step.js
@@ -1,5 +1,5 @@
 import '@brightspace-ui/core/components/button/button.js';
-import { css, html, LitElement } from 'lit-element';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { getLocalizeResources } from './localization.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 import { offscreenStyles } from '@brightspace-ui/core/components/offscreen/offscreen.js';

--- a/d2l-wizard.js
+++ b/d2l-wizard.js
@@ -1,5 +1,5 @@
 import './d2l-single-step-header';
-import { css, html, LitElement } from 'lit-element';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
 
 class D2LWizard extends LitElement {
 	static get properties() {


### PR DESCRIPTION
This PR makes backwards-compatible changes to prepare this repo for a Lit 2 upgrade. Since the changes are backwards compatible, it can be merged right away. 

Non-breaking change checklist: 
- [x] Add missing `.js` extensions for lit-html or lit-element imports 
- [x] `await requestUpdate` -> `await elem.updateComplete` 
- [x] add non-null checks to shadowRoot accesses (not including test files) 
  - No calls before connectedCallback ✔️ 
- [x] audit usages of `unsafeHTML` to ensure `null`, `undefined` inputs are handled as expected 
- [x] remove dynamic code from inside `<template>` tags (Lit files only) 
- [x] remove any dependencies on old Lit versions 
- [x] audit `ifDefined` usages for null parameters 

For more information on the Lit 2 upgrade, visit https://lit.dev/docs/releases/upgrade/ or contact team Gaudi. 