### PR TITLE
US135825 Lit 2 Migration - Phase 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
   },
   "homepage": "https://github.com/BrightspaceUILabs/wizard#readme",
   "dependencies": {
-    "@brightspace-ui/core": "^1.92.0",
+    "@brightspace-ui/core": "^2",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "@webcomponents/webcomponentsjs": "^2.4.1",
-    "lit-element": "^2.2.1"
+    "lit-element": "^3"
   },
   "devDependencies": {
     "@babel/core": "^7.13.8",
@@ -57,7 +57,7 @@
     "wct-browser-legacy": "^1",
     "lit-analyzer": "^1",
     "karma-sauce-launcher": "^4",
-    "@open-wc/testing": "^2",
+    "@open-wc/testing": "^3",
     "@open-wc/testing-karma": "^4",
     "stylelint": "^13"
   }


### PR DESCRIPTION
[US135825 ](https://rally1.rallydev.com/#/431372673576ud/iterationstatus?detail=%2Fuserstory%2F623965078531)

This PR makes the breaking changes required to update to Lit 2 (`lit-html` 2 and `lit-element` 3). The Lit 2 upgrade will be a coordinated effort, so **this PR should not merge at this time**. 

Breaking change checklist:  
- [x] Update `lit-html` -> `^2`, `lit-element` -> `^3`, `open-wc/testing` -> `^3` (if used) 
- [x] `createRenderRoot` usages -> move from LitElement to ReactiveElement  
- [x] Remove Dependabot Lit rules 
- [x] Bump any dependencies to their Lit 2 versions 
- [x] Remove any manual lifecycle calls to Lit 1 reactive controllers 
- [x] Backwards-compatible changes merged: https://github.com/BrightspaceUILabs/wizard/pull/59

Renamed API's: 
- [x] `UpdatingElement` -> `ReactiveElement` 
- [x] `@internalProperty` -> `@state` (we don't use TypeScript decorators) 
- [x] `static getStyles()` -> `static finalizeStyles(styles)` 
- [x] `_getUpdateComplete()` -> `getUpdateComplete()` 
- [x] `NodePart` -> `ChildPart` 

Testing checklist:  
- [x] CI/ unit tests pass 
- [x] Local testing on demo pages 
- [x] Testing component in the LMS – test in custom-early-progress-report or custom-ads-scheduler instead

For more information on the Lit 2 upgrade, visit https://lit.dev/docs/releases/upgrade/ or contact team Gaudi. 