### PR TITLE
US137186 - Switch wizard to incremental-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ jobs:
           persist-credentials: false
       - name: Setup Node
         uses: Brightspace/third-party-actions@actions/setup-node
-      - name: Semantic Release
-        uses: BrightspaceUI/actions/semantic-release@master
+      - name: Incremental Release
+        id: incremental-release
+        uses: BrightspaceUI/actions/incremental-release@master
         with:
+          DEFAULT_INCREMENT: patch
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
-          NPM: true
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -107,39 +107,29 @@ npm run test
 
 ## Versioning & Releasing
 
-> TL;DR: Commits prefixed with `fix:` and `feat:` will trigger patch and minor releases when merged to `master`. Read on for more details...
+The [incremental-release GitHub Action](https://github.com/BrightspaceUI/actions/tree/main/incremental-release) is called from the `release.yml` GitHub Action workflow to handle version changes and releasing.
 
-The [sematic-release GitHub Action](https://github.com/BrightspaceUI/actions/tree/master/semantic-release) is called from the `release.yml` GitHub Action workflow to handle version changes and releasing.
+### Triggering a Release
 
-### Version Changes
+Releases occur based on the most recent commit message:
+* Commits which contain `[increment patch]` will trigger a `patch` release. Example: `validate input before using [increment patch]`
+* Commits which contain `[increment minor]` will trigger a `minor` release. Example: `add toggle() method [increment minor]`
+* Commits which contain `[increment major]` will trigger a `major` release. Example: `breaking all the things [increment major]`
 
-All version changes should obey [semantic versioning](https://semver.org/) rules:
-1. **MAJOR** version when you make incompatible API changes,
-2. **MINOR** version when you add functionality in a backwards compatible manner, and
-3. **PATCH** version when you make backwards compatible bug fixes.
+**Note:** When merging a pull request, this will be the merge commit message.
 
-The next version number will be determined from the commit messages since the previous release. Our semantic-release configuration uses the [Angular convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular) when analyzing commits:
-* Commits which are prefixed with `fix:` or `perf:` will trigger a `patch` release. Example: `fix: validate input before using`
-* Commits which are prefixed with `feat:` will trigger a `minor` release. Example: `feat: add toggle() method`
-* To trigger a MAJOR release, include `BREAKING CHANGE:` with a space or two newlines in the footer of the commit message
-* Other suggested prefixes which will **NOT** trigger a release: `build:`, `ci:`, `docs:`, `style:`, `refactor:` and `test:`. Example: `docs: adding README for new component`
+### Default Increment
 
-To revert a change, add the `revert:` prefix to the original commit message. This will cause the reverted change to be omitted from the release notes. Example: `revert: fix: validate input before using`.
+Normally, if the most recent commit does not contain `[increment major|minor|patch]`, no release will occur. However, by setting the `DEFAULT_INCREMENT` option you can control which type of release will occur. This repo has the `DEFAULT_INCREMENT` set to be a `patch` release.
 
-### Releases
+In this example, a minor release will occur if no increment value is found in the most recent commit:
 
-When a release is triggered, it will:
-* Update the version in `package.json`
-* Tag the commit
-* Create a GitHub release (including release notes)
-* Deploy a new package to NPM
+```yml
+uses: BrightspaceUI/actions/incremental-release@main
+with:
+  DEFAULT_INCREMENT: minor
+```
 
-### Releasing from Maintenance Branches
+### Skipping Releases
 
-Occasionally you'll want to backport a feature or bug fix to an older release. `semantic-release` refers to these as [maintenance branches](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#maintenance-branches).
-
-Maintenance branch names should be of the form: `+([0-9])?(.{+([0-9]),x}).x`.
-
-Regular expressions are complicated, but this essentially means branch names should look like:
-* `1.15.x` for patch releases on top of the `1.15` release (after version `1.16` exists)
-* `2.x` for feature releases on top of the `2` release (after version `3` exists)
+When a default increment is specified, sometimes you want to bypass it and skip a release. To do this, include `[skip version]` in the commit message.


### PR DESCRIPTION
* Switch from `semantic-release` to `incremental-release` to minimize manual steps.
* Update README

Rally: [US137186](https://rally1.rallydev.com/#/?detail=/userstory/629877883047&fdp=true): Maintenance, dependency, translation updates (2022-03-21 sprint)