### PR TITLE
US139401 chore: add commitlint config

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,5 @@
+{
+    "extends": [
+        "@commitlint/config-conventional"
+    ]
+}

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no -- commitlint --edit $1

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "npm run lint && npm run test:headless",
     "test:headless": "karma start",
     "test:headless:watch": "karma start --auto-watch=true --single-run=false",
-    "test:sauce": "karma start karma.sauce.conf.js"
+    "test:sauce": "karma start karma.sauce.conf.js",
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",
@@ -44,6 +45,8 @@
     "@babel/plugin-proposal-class-properties": "^7.13.0",
     "@babel/polyfill": "^7",
     "@brightspace-ui/stylelint-config": "^0.4",
+    "@commitlint/cli": "^17.0.0",
+    "@commitlint/config-conventional": "^17.0.0",
     "@open-wc/testing": "^3",
     "@open-wc/testing-karma": "^4",
     "deepmerge": "^4",
@@ -54,6 +57,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-lit": "^1",
     "eslint-plugin-sort-class-members": "^1",
+    "husky": "^8.0.0",
     "karma-sauce-launcher": "^4",
     "lit-analyzer": "^1",
     "stylelint": "^14",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "karma-sauce-launcher": "^4",
     "lit-analyzer": "^1",
     "stylelint": "^14",
+    "ts-node": "10.2.1",
     "wct-browser-legacy": "^1"
   }
 }


### PR DESCRIPTION
[US139401](https://rally1.rallydev.com/#/?detail=/userstory/637950879437&fdp=true)

This adds a basic [commitlint](https://commitlint.js.org/) configuration to the project using [config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional).

![2022-05-18 1](https://user-images.githubusercontent.com/60618395/169314190-66864488-0bdd-44bc-a22c-402de8c4dc53.gif)
