### PR TITLE
chore: US139401 - update linter config

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,5 +1,12 @@
 {
     "extends": [
         "@commitlint/config-conventional"
-    ]
+    ],
+    "rules": {
+      "subject-case": [
+        0,
+        "never",
+        []
+      ]
+    }
 }

--- a/README.md
+++ b/README.md
@@ -144,3 +144,7 @@ Maintenance branch names should be of the form: `+([0-9])?(.{+([0-9]),x}).x`.
 Regular expressions are complicated, but this essentially means branch names should look like:
 * `1.15.x` for patch releases on top of the `1.15` release (after version `1.16` exists)
 * `2.x` for feature releases on top of the `2` release (after version `3` exists)
+
+### Dependabot
+
+Until the `ts-node` [issue](https://github.com/BrightspaceUILabs/wizard/pull/83#issuecomment-1131935120) is resolved, do not merge Dependabot PRs that seek to upgrade `ts-node`.  Other dependency updates should be handled normally.


### PR DESCRIPTION
* Override `subject-case` rule to allow commit subjects of our usual form beginning with the user story `USxxxxxx`
* Add reminder not to upgrade `ts-node` for now.

Rally: [US139401](https://rally1.rallydev.com/#/?detail=/userstory/637950879437&fdp=true): [SPIKE] Commit linter (for semantic release)