### PR TITLE
fix: lit dependencies

### DIFF
--- a/d2l-single-step-header.js
+++ b/d2l-single-step-header.js
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { css, html, LitElement } from 'lit';
 import { bodySmallStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { getLocalizeResources } from './localization.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';

--- a/d2l-step.js
+++ b/d2l-step.js
@@ -1,5 +1,5 @@
 import '@brightspace-ui/core/components/button/button.js';
-import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { css, html, LitElement } from 'lit';
 import { getLocalizeResources } from './localization.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 import { offscreenStyles } from '@brightspace-ui/core/components/offscreen/offscreen.js';

--- a/d2l-wizard.js
+++ b/d2l-wizard.js
@@ -1,5 +1,5 @@
 import './d2l-single-step-header.js';
-import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { css, html, LitElement } from 'lit';
 
 class D2LWizard extends LitElement {
 	static get properties() {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/BrightspaceUILabs/wizard#readme",
   "dependencies": {
     "@brightspace-ui/core": "^2",
-    "lit-element": "^3"
+    "lit": "^2"
   },
   "devDependencies": {
     "@babel/core": "^7.13.8",


### PR DESCRIPTION
This isn't a prerequisite for upgrading to Lit 3 next year, but cleaning up the warnings would be nice. Both `lit-element` and `lit-html` have been rolled into `lit` for quite some time.